### PR TITLE
feat: switch from hash routing to browser-history routing

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,11 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- <title>Landing Page | Hikari personal website</title> -->
+    <script>
+      // Redirect legacy hash-router URLs (/homepage/#/foo) to real paths
+      if (location.hash.startsWith("#/"))
+        location.replace("/homepage" + location.hash.slice(1));
+    </script>
   </head>
 
   <body>

--- a/prerender-routes-plugin.ts
+++ b/prerender-routes-plugin.ts
@@ -1,0 +1,76 @@
+import type { Plugin, ResolvedConfig } from "vite";
+import fs from "fs";
+import path from "path";
+
+interface PrerenderRoutesOptions {
+  // Route paths that cannot be derived from the files in src/routes,
+  // e.g. the bounded values of a dynamic param.
+  extraPaths?: string[];
+}
+
+// Derive static route paths ("dvd-logo", "cv", ...) from the files in
+// src/routes. Lazy pairs, the root layout and `-`-prefixed files are not
+// routes of their own; "index" is served by the root index.html already.
+function collectRoutePaths(routesDir: string): string[] {
+  return fs
+    .readdirSync(routesDir)
+    .filter(
+      (file) =>
+        file.endsWith(".tsx") &&
+        !file.endsWith(".lazy.tsx") &&
+        !file.startsWith("-") &&
+        file !== "__root.tsx",
+    )
+    .map((file) =>
+      file
+        .slice(0, -".tsx".length)
+        // optional-param segments ("cv.{-$var}") match without the param too
+        .replace(/\.\{-\$[^}]+\}/g, "")
+        // flat-route dots are path separators
+        .replace(/\./g, "/"),
+    )
+    .filter((routePath) => routePath !== "index");
+}
+
+// GitHub Pages has no SPA fallback, so a browser-history deep link like
+// /homepage/dvd-logo 404s unless a real file backs it. Copy the built
+// index.html to both <route>.html (serves the extensionless URL directly)
+// and <route>/index.html (serves the trailing-slash form) for every route.
+export function vitePluginPrerenderRoutes(
+  options: PrerenderRoutesOptions = {},
+): Plugin {
+  let config: ResolvedConfig;
+
+  return {
+    name: "vite-plugin-prerender-routes",
+    apply: "build",
+
+    configResolved(resolved) {
+      config = resolved;
+    },
+
+    closeBundle() {
+      const outDir = path.resolve(config.root, config.build.outDir);
+      const indexHtml = path.join(outDir, "index.html");
+      if (!fs.existsSync(indexHtml)) return;
+
+      const routesDir = path.resolve(config.root, "src/routes");
+      const routePaths = [
+        ...collectRoutePaths(routesDir),
+        ...(options.extraPaths ?? []),
+      ];
+
+      for (const routePath of routePaths) {
+        const flatFile = path.join(outDir, `${routePath}.html`);
+        const dirFile = path.join(outDir, routePath, "index.html");
+        fs.mkdirSync(path.dirname(flatFile), { recursive: true });
+        fs.mkdirSync(path.dirname(dirFile), { recursive: true });
+        fs.copyFileSync(indexHtml, flatFile);
+        fs.copyFileSync(indexHtml, dirFile);
+      }
+      console.log(
+        `[prerender-routes] wrote shells for: ${routePaths.join(", ")}`,
+      );
+    },
+  };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,6 @@
 import { StrictMode } from "react";
 import ReactDOM from "react-dom/client";
-import {
-  RouterProvider,
-  createHashHistory,
-  createRouter,
-} from "@tanstack/react-router";
+import { RouterProvider, createRouter } from "@tanstack/react-router";
 
 // Import the generated route tree
 import { ErrorBoundary } from "@/components/error";
@@ -12,11 +8,10 @@ import { routeTree } from "@/routeTree.gen";
 
 import "@/index.css";
 
-const hashHistory = createHashHistory();
 // Create a new router instance
 const router = createRouter({
   routeTree,
-  history: hashHistory,
+  basepath: "/homepage",
   scrollRestoration: true,
   scrollRestorationBehavior: "smooth",
   defaultViewTransition: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from "@vitejs/plugin-react";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import tailwindcss from "@tailwindcss/vite";
 import { vitePluginImageProcessor } from "./transform-image-plugin";
+import { vitePluginPrerenderRoutes } from "./prerender-routes-plugin";
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -20,6 +21,11 @@ export default defineConfig({
     tailwindcss(),
     vitePluginImageProcessor({
       targetDir: "./src/assets/sites",
+    }),
+    vitePluginPrerenderRoutes({
+      // bounded /cv/{-$var} values — keep in sync with getCVContext in
+      // src/data/cv-context.ts
+      extraPaths: ["cv/default", "cv/su"],
     }),
   ],
 });


### PR DESCRIPTION
## What

- `src/main.tsx`: drop `createHashHistory`; router uses browser history with `basepath: "/homepage"`.
- `prerender-routes-plugin.ts` (new): build-only plugin that derives static route paths from `src/routes/*.tsx` and copies the built `index.html` to both `<route>.html` and `<route>/index.html`, so deep links work on GitHub Pages (no SPA fallback there) without the 404.html redirect trick. Both `/homepage/foo` and `/homepage/foo/` resolve with zero redirects.
- `vite.config.ts`: registers the plugin with `extraPaths: ["cv/default", "cv/su"]` for the bounded `/cv/{-$var}` values (kept in sync with `getCVContext`).
- `index.html`: 3-line shim redirecting legacy `/#/foo` hash URLs to real paths so old shared links keep working.

## Verified

- `npm run check` passes (format, lint, typecheck, build).
- Build emits shells for all 11 static routes plus `cv/default` and `cv/su`.
- Dev server serves all deep links (`/homepage/dvd-logo`, `/homepage/cv/su`, …) via Vite's SPA fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)