### PR TITLE
feat: keep CV pages out of search results

### DIFF
--- a/prerender-routes-plugin.ts
+++ b/prerender-routes-plugin.ts
@@ -6,6 +6,9 @@ interface PrerenderRoutesOptions {
   // Route paths that cannot be derived from the files in src/routes,
   // e.g. the bounded values of a dynamic param.
   extraPaths?: string[];
+  // Route paths whose shells get a robots noindex meta tag so search
+  // engines leave them out of results.
+  noindexPaths?: string[];
 }
 
 // Derive static route paths ("dvd-logo", "cv", ...) from the files in
@@ -60,13 +63,21 @@ export function vitePluginPrerenderRoutes(
         ...(options.extraPaths ?? []),
       ];
 
+      const shellHtml = fs.readFileSync(indexHtml, "utf-8");
+      const noindexShellHtml = shellHtml.replace(
+        "</head>",
+        '  <meta name="robots" content="noindex" />\n  </head>',
+      );
+      const noindexPaths = new Set(options.noindexPaths ?? []);
+
       for (const routePath of routePaths) {
+        const html = noindexPaths.has(routePath) ? noindexShellHtml : shellHtml;
         const flatFile = path.join(outDir, `${routePath}.html`);
         const dirFile = path.join(outDir, routePath, "index.html");
         fs.mkdirSync(path.dirname(flatFile), { recursive: true });
         fs.mkdirSync(path.dirname(dirFile), { recursive: true });
-        fs.copyFileSync(indexHtml, flatFile);
-        fs.copyFileSync(indexHtml, dirFile);
+        fs.writeFileSync(flatFile, html);
+        fs.writeFileSync(dirFile, html);
       }
       console.log(
         `[prerender-routes] wrote shells for: ${routePaths.join(", ")}`,

--- a/src/routes/cv.{-$var}.tsx
+++ b/src/routes/cv.{-$var}.tsx
@@ -8,6 +8,10 @@ export const Route = createFileRoute("/cv/{-$var}")({
         {
           title: getCVRevText(params.var),
         },
+        {
+          name: "robots",
+          content: "noindex",
+        },
       ],
     };
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
       // bounded /cv/{-$var} values — keep in sync with getCVContext in
       // src/data/cv-context.ts
       extraPaths: ["cv/default", "cv/su"],
+      noindexPaths: ["cv", "cv/default", "cv/su"],
     }),
   ],
 });


### PR DESCRIPTION
- `prerender-routes-plugin.ts`: new `noindexPaths` option — shells for listed paths get `<meta name="robots" content="noindex" />` injected before `</head>`.
- `vite.config.ts`: `noindexPaths: ["cv", "cv/default", "cv/su"]`.
- `src/routes/cv.{-$var}.tsx`: same robots meta in `head()` so the rendered DOM carries the signal too.

Verified: `npm run check` passes; all 6 cv shell files contain the meta tag, `dist/index.html` and other route shells do not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)